### PR TITLE
Add ShellCheck CI and dependency installer

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,14 +1,14 @@
 name: shellcheck
 on:
   pull_request:
-    paths: ['**/*.sh']
+    paths: ['/*.sh']
   push:
     branches: [ main ]
-    paths: ['**/*.sh']
+    paths: ['/*.sh']
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - run: sudo apt-get update && sudo apt-get install -y shellcheck
-      - run: shellcheck -S style -x proxmox-manager.sh
+    - uses: actions/checkout@v4
+    - run: sudo apt-get update && sudo apt-get install -y shellcheck
+    - run: shellcheck -S style -x proxmox-manager.sh

--- a/README.md
+++ b/README.md
@@ -1,7 +1,29 @@
-```
-cd ~
-nano proxmox-manager.sh
-# (Inhalt aus dem nächsten Block komplett einfügen, speichern)
-chmod +x proxmox-manager.sh
+# Proxmox VM/CT Management Tool
+
+A lightweight TUI helper to list & manage Proxmox VMs/containers via `qm`/`pct`.
+
+## Features
+- Robust listing (names with spaces supported)
+- Start / Stop / Restart / Status
+- Open console (`pct enter`, `qm terminal` → fallback `qm monitor`)
+- Snapshot management (list / create / rollback / delete)
+- SPICE info + `.vv` file generation, enable SPICE
+- Permission checks, clear TUI
+
+## Quick start (on a Proxmox node)
+```bash
+apt update && apt install -y git
+cd /root && git clone git@github.com:TimInTech/proxmox-manager.git
+cd proxmox-manager
+chmod +x proxmox-manager.sh install_dependencies.sh
+./install_dependencies.sh    # optional helpers (shellcheck, remote-viewer, etc.)
 ./proxmox-manager.sh
 ```
+
+Notes
+
+Run as root on a Proxmox node (needs qm and/or pct)
+
+SPICE: tool shows spice://HOST:PORT and writes /tmp/vm-<id>.vv
+
+CI: ShellCheck workflow lints the script on push/PR

--- a/install_dependencies.sh
+++ b/install_dependencies.sh
@@ -1,69 +1,38 @@
 #!/usr/bin/env bash
-# install_dependencies.sh
-# Purpose: Install minimal runtime dependencies for proxmox-manager.sh on a Proxmox host
-# Tested on Proxmox VE 8 (Debian bookworm) & 9 (Debian trixie)
+# install_dependencies.sh - install optional helpers for proxmox-manager
+# Idempotent install script for Debian/Proxmox nodes
 
-set -Eeuo pipefail
+set -euo pipefail
 
-RED="\033[1;31m"; GREEN="\033[1;32m"; YELLOW="\033[1;33m"; CYAN="\033[1;36m"; NC="\033[0m"
+log() { echo -e "$1"; }
+err() { echo -e "$1" >&2; }
 
-need_root() {
-  if [[ "${EUID:-$(id -u)}" -ne 0 ]]; then
-    echo -e "${RED}Please run as root (sudo -i).${NC}"
-    exit 1
-  fi
-}
-
-have() { command -v "$1" >/dev/null 2>&1; }
-
-need_root
-
-echo -e "${CYAN}==> Detecting system & Proxmox version…${NC}"
-if have pveversion; then
-  echo -e "Proxmox: $(pveversion || true)"
-else
-  echo -e "${YELLOW}Note: 'pveversion' not found. Is this really a Proxmox host?${NC}"
+if [[ ${EUID:-$(id -u)} -ne 0 ]]; then
+  err "Please run as root."
+  exit 1
 fi
 
-echo -e "${CYAN}==> Running apt update…${NC}"
-apt-get update -y
-
-# Core packages (most are preinstalled on Debian/Proxmox, but ensure they exist)
-PKGS=(
-  bash coreutils grep sed gawk procps
-  curl git
-  jq            # useful for future JSON handling
-  shellcheck    # optional, for linting shell scripts
-)
-
-echo -e "${CYAN}==> Installing/ensuring packages:${NC} ${PKGS[*]}"
-apt-get install -y "${PKGS[@]}"
-
-# Proxmox CLI tools
-MISSING_PVE=0
-if ! have qm; then
-  echo -e "${YELLOW}Warning: 'qm' not found. (Normal if not running on Proxmox VE)${NC}"
-  MISSING_PVE=1
-fi
-if ! have pct; then
-  echo -e "${YELLOW}Warning: 'pct' not found. (Normal if not running on Proxmox VE)${NC}"
-  MISSING_PVE=1
-fi
-
-# Summary
-echo -e "${GREEN}==> Done.${NC}"
-echo -e "Installed and available binaries:"
-for c in bash qm pct awk sed grep curl git jq shellcheck; do
-  if have "$c"; then
-    echo -e "  • ${c}: $( ( "$c" --version 2>/dev/null || "$c" -V 2>/dev/null || true ) | head -n1 )"
-  else
-    echo -e "  • ${c}: ${RED}MISSING${NC}"
+PKGS=(curl git shellcheck virt-viewer jq)
+MISSING=()
+for pkg in "${PKGS[@]}"; do
+  if ! dpkg -s "$pkg" >/dev/null 2>&1; then
+    MISSING+=("$pkg")
   fi
 done
 
-if (( MISSING_PVE )); then
-  echo -e "${YELLOW}Note:${NC} Without 'qm' and 'pct' some script functions will be disabled."
+if (( ${#MISSING[@]} )); then
+  log "Updating package lists..."
+  if ! apt-get update; then
+    err "apt-get update failed"
+    exit 1
+  fi
+  log "Installing packages: ${MISSING[*]}"
+  if ! apt-get install -y "${MISSING[@]}"; then
+    err "Package installation failed"
+    exit 1
+  fi
+else
+  log "All packages already installed."
 fi
 
-echo -e "${GREEN}System ready. You can now run './proxmox-manager.sh'.${NC}"
-
+log "Done."

--- a/proxmox-manager.sh
+++ b/proxmox-manager.sh
@@ -4,7 +4,7 @@
 set -Eeuo pipefail
 
 # Farben
-BOLD="\033[1m"; BLUE="\033[1;34m"; CYAN="\033[1;36m"; GREEN="\033[1;32m"; YELLOW="\033[1;33m"; RED="\033[1;31m"; NC="\033[0m"
+BLUE="\033[1;34m"; CYAN="\033[1;36m"; GREEN="\033[1;32m"; YELLOW="\033[1;33m"; RED="\033[1;31m"; NC="\033[0m"
 
 # Graceful exit
 trap 'echo -e "\n\nScript beendet."; exit 0' INT TERM
@@ -56,19 +56,11 @@ collect_all_instances() {
 
   # CTs
   if have pct; then
-    while IFS= read -r line; do
-      [[ -z "$line" ]] && continue
-      [[ "$line" =~ ^[[:space:]]*VMID ]] && continue
-      [[ "$line" =~ ^[[:space:]]*[0-9]+ ]] || continue
+    while read -r vmid status _; do
+      [[ -z "$vmid" ]] && continue
 
-      local vmid status name symbol
-      vmid="$(awk '{print $1}' <<<"$line")"
-      status="$(awk '{for(i=1;i<=NF;i++) if($i=="running"||$i=="stopped"||$i=="paused"){print $i; exit}}' <<<"$line" || true)"
-      if [[ -n "$status" ]]; then
-        name="$(sed -E "s/^[[:space:]]*${vmid}[[:space:]]+//; s/[[:space:]]+${status}.*//" <<<"$line" | sed -E 's/^[[:space:]]+|[[:space:]]+$//')"
-      else
-        name="$(sed -E "s/^[[:space:]]*${vmid}[[:space:]]+//" <<<"$line" | sed -E 's/^[[:space:]]+|[[:space:]]+$//')"
-      fi
+      local name symbol
+      name="$(pct config "$vmid" 2>/dev/null | awk -F': ' '/^hostname:/ {print $2}' | sed -E 's/^[[:space:]]+|[[:space:]]+$//')"
       [[ -z "$name" ]] && name="CT-${vmid}"
       [[ -z "$status" ]] && status="unknown"
 
@@ -78,7 +70,7 @@ collect_all_instances() {
       [[ "$status" == "paused" ]] && symbol="🟠"
 
       instance_info+=("$vmid" "CT" "$symbol" "$name" "$status")
-    done < <(pct list 2>/dev/null || true)
+    done < <(pct list 2>/dev/null | awk 'NR>1 {print $1, $2}' || true)
   fi
 
   # VMs
@@ -118,8 +110,7 @@ collect_all_instances() {
     map+=("${instance_info[i]}:$i")
   done
 
-  IFS=$'\n' map=($(sort -n -t: -k1 <<<"${map[*]}"))
-  unset IFS
+  readarray -t map < <(printf '%s\n' "${map[@]}" | sort -n -t: -k1)
   for entry in "${map[@]}"; do
     local idx="${entry#*:}"
     sorted_info+=("${instance_info[idx]}" "${instance_info[idx+1]}" "${instance_info[idx+2]}" "${instance_info[idx+3]}" "${instance_info[idx+4]}")


### PR DESCRIPTION
## Summary
- document tool usage and features
- add idempotent dependency install script
- configure ShellCheck workflow for root-level scripts
- resolve ShellCheck warnings in main script
- fix CT name parsing so status doesn't repeat

## Testing
- `shellcheck -S style -x proxmox-manager.sh`
- `./install_dependencies.sh`
- `timeout 6s bash -lc 'printf "q\n" | ./proxmox-manager.sh'` *(fails: Proxmox commands not available)*

------
https://chatgpt.com/codex/tasks/task_e_68b41eede1f483339b52a49a830f2bd5